### PR TITLE
Integration Test with security dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ subprojects {
     def subArchivesBaseName = props.getProperty('archivesBaseName')
     def archName = subArchivesBaseName.substring(1, subArchivesBaseName.length() - 1)
 
+
+    sourceCompatibility = '1.8'
+
     java {
         withSourcesJar()
     }

--- a/jmix-addon-template/jmix-addon-template.gradle
+++ b/jmix-addon-template/jmix-addon-template.gradle
@@ -6,6 +6,11 @@ dependencies {
     implementation 'io.jmix.ui:jmix-ui-starter'
     implementation 'io.jmix.ui:jmix-ui-themes'
 
+
+    implementation 'io.jmix.security:jmix-security-starter'
+    implementation 'io.jmix.security:jmix-security-data-starter'
+
+
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }

--- a/jmix-addon-template/src/main/java/io/jmix/addon/template/AddonConfiguration.java
+++ b/jmix-addon-template/src/main/java/io/jmix/addon/template/AddonConfiguration.java
@@ -18,7 +18,11 @@ import java.util.Collections;
 @Configuration
 @ComponentScan
 @ConfigurationPropertiesScan
-@JmixModule(dependsOn = {EclipselinkConfiguration.class, UiConfiguration.class, SecurityDataConfiguration.class})
+@JmixModule(id = "io.jmix.addon.template", dependsOn = {
+        EclipselinkConfiguration.class,
+        UiConfiguration.class,
+        SecurityDataConfiguration.class
+})
 @PropertySource(name = "io.jmix.addon.template", value = "classpath:/io/jmix/addon/template/module.properties")
 public class AddonConfiguration {
 

--- a/jmix-addon-template/src/main/java/io/jmix/addon/template/AddonConfiguration.java
+++ b/jmix-addon-template/src/main/java/io/jmix/addon/template/AddonConfiguration.java
@@ -5,6 +5,7 @@ import io.jmix.core.impl.scanning.AnnotationScanMetadataReaderFactory;
 import io.jmix.eclipselink.EclipselinkConfiguration;
 import io.jmix.ui.UiConfiguration;
 import io.jmix.ui.sys.UiControllersConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityDataConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +18,7 @@ import java.util.Collections;
 @Configuration
 @ComponentScan
 @ConfigurationPropertiesScan
-@JmixModule(dependsOn = {EclipselinkConfiguration.class, UiConfiguration.class})
+@JmixModule(dependsOn = {EclipselinkConfiguration.class, UiConfiguration.class, SecurityDataConfiguration.class})
 @PropertySource(name = "io.jmix.addon.template", value = "classpath:/io/jmix/addon/template/module.properties")
 public class AddonConfiguration {
 

--- a/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTest.java
+++ b/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTest.java
@@ -3,6 +3,8 @@ package io.jmix.addon.template;
 import io.jmix.addon.template.test_support.entity.Foo;
 import io.jmix.core.DataManager;
 import io.jmix.core.Id;
+import io.jmix.core.UnconstrainedDataManager;
+import io.jmix.core.security.SystemAuthenticator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +15,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class AddonTest {
 
 	@Autowired
-	DataManager dataManager;
+	UnconstrainedDataManager dataManager;
+	@Autowired
+	SystemAuthenticator systemAuthenticator;
 
 	@Test
 	void contextLoads() {
@@ -21,13 +25,20 @@ class AddonTest {
 
 	@Test
 	void testFoo() {
-		Foo foo = dataManager.create(Foo.class);
-		foo.setName("abc");
 
-		Foo foo1 = dataManager.save(foo);
-		assertEquals(foo, foo1);
+		systemAuthenticator.withSystem(() ->  {
+			Foo foo = dataManager.create(Foo.class);
+			foo.setName("abc");
 
-		Foo foo2 = dataManager.load(Id.of(foo)).one();
-		assertEquals(foo, foo2);
+			Foo foo1 = dataManager.save(foo);
+			assertEquals(foo, foo1);
+
+			Foo foo2 = dataManager.load(Id.of(foo)).one();
+			assertEquals(foo, foo2);
+
+			return "Done";
+		});
+
+
 	}
 }

--- a/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTest.java
+++ b/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTest.java
@@ -3,42 +3,88 @@ package io.jmix.addon.template;
 import io.jmix.addon.template.test_support.entity.Foo;
 import io.jmix.core.DataManager;
 import io.jmix.core.Id;
+import io.jmix.core.JmixModuleDescriptor;
+import io.jmix.core.JmixModules;
 import io.jmix.core.UnconstrainedDataManager;
 import io.jmix.core.security.SystemAuthenticator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class AddonTest {
 
-	@Autowired
-	UnconstrainedDataManager dataManager;
-	@Autowired
-	SystemAuthenticator systemAuthenticator;
+    @Autowired
+    UnconstrainedDataManager dataManager;
+    @Autowired
+    SystemAuthenticator systemAuthenticator;
+    @Autowired
+    JmixModules jmixModules;
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
-	@Test
-	void testFoo() {
+    @Test
+    void testFoo() {
 
-		systemAuthenticator.withSystem(() ->  {
-			Foo foo = dataManager.create(Foo.class);
-			foo.setName("abc");
+        systemAuthenticator.withSystem(() -> {
+            Foo foo = dataManager.create(Foo.class);
+            foo.setName("abc");
 
-			Foo foo1 = dataManager.save(foo);
-			assertEquals(foo, foo1);
+            Foo foo1 = dataManager.save(foo);
+            assertEquals(foo, foo1);
 
-			Foo foo2 = dataManager.load(Id.of(foo)).one();
-			assertEquals(foo, foo2);
+            Foo foo2 = dataManager.load(Id.of(foo)).one();
+            assertEquals(foo, foo2);
 
-			return "Done";
-		});
+            return "Done";
+        });
 
 
-	}
+    }
+
+    /**
+     * currently is working, but it should actually failing, since the addon modules should come last
+     */
+    @Test
+    void wrongOrderOfJmixModules() {
+
+        assertThat(jmixModules.getAll().stream().map(JmixModuleDescriptor::getId))
+				.containsExactly(
+                        "io.jmix.core",
+                        "io.jmix.data",
+                        "io.jmix.eclipselink",
+                        "io.jmix.ui",
+                        "io.jmix.security",
+                        "io.jmix.securitydata",
+
+                        "io.jmix.addon.template",
+                        "io.jmix.addon.template.test"
+                );
+    }
+
+    /**
+     * currently fails although it should work.
+     */
+    @Test
+    void correctOrderOfJmixModules() {
+
+        assertThat(jmixModules.getAll().stream().map(JmixModuleDescriptor::getId))
+				.containsExactly(
+                        "io.jmix.core",
+                        "io.jmix.data",
+                        "io.jmix.eclipselink",
+                        "io.jmix.ui",
+                        "io.jmix.security",
+                        "io.jmix.securitydata",
+
+                        // those should be the last items in the list
+                        "io.jmix.addon.template",
+                        "io.jmix.addon.template.test"
+                );
+    }
 }

--- a/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
+++ b/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
@@ -3,8 +3,11 @@ package io.jmix.addon.template;
 import io.jmix.core.annotation.JmixModule;
 import io.jmix.core.security.InMemoryUserRepository;
 import io.jmix.core.security.UserRepository;
+import io.jmix.eclipselink.EclipselinkConfiguration;
+import io.jmix.ui.UiConfiguration;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.SecurityDataConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
@@ -16,7 +19,7 @@ import javax.sql.DataSource;
 @SpringBootConfiguration
 @EnableAutoConfiguration
 @Import(AddonConfiguration.class)
-@JmixModule(dependsOn = AddonConfiguration.class)
+@JmixModule(dependsOn = {AddonConfiguration.class, EclipselinkConfiguration.class, UiConfiguration.class, SecurityDataConfiguration.class})
 public class AddonTestConfiguration {
 
 

--- a/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
+++ b/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
@@ -1,6 +1,8 @@
 package io.jmix.addon.template;
 
 import io.jmix.core.annotation.JmixModule;
+import io.jmix.core.security.InMemoryUserRepository;
+import io.jmix.core.security.UserRepository;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +18,12 @@ import javax.sql.DataSource;
 @Import(AddonConfiguration.class)
 @JmixModule(dependsOn = AddonConfiguration.class)
 public class AddonTestConfiguration {
+
+
+    @Bean
+    public UserRepository userRepository() {
+        return new InMemoryUserRepository();
+    }
 
     @Bean
     @Primary

--- a/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
+++ b/jmix-addon-template/src/test/java/io/jmix/addon/template/AddonTestConfiguration.java
@@ -19,7 +19,7 @@ import javax.sql.DataSource;
 @SpringBootConfiguration
 @EnableAutoConfiguration
 @Import(AddonConfiguration.class)
-@JmixModule(dependsOn = {AddonConfiguration.class, EclipselinkConfiguration.class, UiConfiguration.class, SecurityDataConfiguration.class})
+@JmixModule(id = "io.jmix.addon.template.test", dependsOn = AddonConfiguration.class)
 public class AddonTestConfiguration {
 
 

--- a/jmix-studio.xml
+++ b/jmix-studio.xml
@@ -15,6 +15,19 @@
           </option>
         </ModuleSettings>
       </entry>
+      <entry key="jmix-addon-template-addon.jmix-addon-template.test">
+        <ModuleSettings>
+          <option name="dataStoreOptions">
+            <map>
+              <entry key="main">
+                <value>
+                  <DataStoreSettings />
+                </value>
+              </entry>
+            </map>
+          </option>
+        </ModuleSettings>
+      </entry>
     </moduleSettings>
   </component>
 </project>


### PR DESCRIPTION
When adding the dependency to the security subsystem and trying to adjust the tests accordingly, the following exception occurs:

```java

Object: io.jmix.addon.template.test_support.entity.Foo-663ec1e9-2eb8-99ef-46dc-f1a64ef8dce2 [new] is not a known Entity type.
java.lang.IllegalArgumentException: Object: io.jmix.addon.template.test_support.entity.Foo-663ec1e9-2eb8-99ef-46dc-f1a64ef8dce2 [new] is not a known Entity type.
	at org.eclipse.persistence.internal.sessions.UnitOfWorkImpl.registerNewObjectForPersist(UnitOfWorkImpl.java:4419)
	at org.eclipse.persistence.internal.jpa.EntityManagerImpl.persist(EntityManagerImpl.java:601)
	at io.jmix.eclipselink.impl.JmixEntityManager.internalPersist(JmixEntityManager.java:415)
	at io.jmix.eclipselink.impl.JmixEntityManager.persist(JmixEntityManager.java:92)
	at io.jmix.eclipselink.impl.JpaDataStore.saveAll(JpaDataStore.java:228)
	at io.jmix.core.datastore.AbstractDataStore.save(AbstractDataStore.java:221)
	at io.jmix.core.impl.UnconstrainedDataManagerImpl.saveContextToStore(UnconstrainedDataManagerImpl.java:257)
	at io.jmix.core.impl.UnconstrainedDataManagerImpl.save(UnconstrainedDataManagerImpl.java:216)
	at io.jmix.core.impl.UnconstrainedDataManagerImpl.save(UnconstrainedDataManagerImpl.java:135)
	at io.jmix.addon.template.AddonTest.lambda$testFoo$0(AddonTest.java:33)
	at io.jmix.core.security.impl.SystemAuthenticatorImpl.withSystem(SystemAuthenticatorImpl.java:120)
	at io.jmix.addon.template.AddonTest.testFoo(AddonTest.java:29)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:108)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:96)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:75)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)

```

see also https://github.com/mariodavid/jmix-addon-template/runs/4689788099?check_suite_focus=true

When doing it without security, everything works fine: (see main: https://github.com/mariodavid/jmix-addon-template/runs/4689699665?check_suite_focus=true)